### PR TITLE
0.0.9

### DIFF
--- a/bin/cli-utils.js
+++ b/bin/cli-utils.js
@@ -93,7 +93,7 @@ Utils.getClient = function(args, opts, cb) {
   opts = opts || {};
 
   var filename = args.file || process.env['WALLET_FILE'] || process.env['HOME'] + '/.wallet.dat';
-  var host = args.host || process.env['BWS_HOST'] || 'http://localhost:3001/';
+  var host = args.host || process.env['BWS_HOST'] || 'https://bws.bitpay.com/';
 
   var storage = new FileStorage({
     filename: filename,

--- a/bin/wallet-create
+++ b/bin/wallet-create
@@ -27,7 +27,7 @@ try {
 }
 
 utils.getClient(program, { doNotComplete: true }, function (client) {
-  client.createWallet(walletName, copayerName, mn[0], mn[1], network, function(err, secret) {
+  client.createWallet(walletName, copayerName, mn[0], mn[1], {network: network}, function(err, secret) {
     utils.die(err);
     console.log(' * ' + _.capitalize(network) + ' Wallet Created.');
     utils.saveClient(program, client, function () {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/bitpay/bitcore-wallet/issues"
   },
   "dependencies": {
-    "bitcore-wallet-client": "^0.0.9",
+    "bitcore-wallet-client": "0.0.22",
     "commander": "^2.6.0",
     "lodash": "^3.3.1",
     "moment": "^2.9.0",
@@ -33,13 +33,16 @@
     "test": "./node_modules/.bin/mocha",
     "coveralls": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
-  "contributors": [{
-    "name": "Ivan Socolsky",
-    "email": "ivan@gmail.com"
-  }, {
-    "name": "Matias Alejo Garcia",
-    "email": "ematiu@gmail.com"
-  }],
+  "contributors": [
+    {
+      "name": "Ivan Socolsky",
+      "email": "ivan@gmail.com"
+    },
+    {
+      "name": "Matias Alejo Garcia",
+      "email": "ematiu@gmail.com"
+    }
+  ],
   "bin": {
     "wallet": "./bin/wallet",
     "wallet-address": "./bin/wallet-address",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bitcore-wallet",
   "description": "A CLI Mutisig HD Bitcoin Wallet, demo for Bitcore Wallet Service",
   "author": "BitPay Inc",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "keywords": [
     "bitcoin",
     "copay",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bitcore-wallet",
   "description": "A CLI Mutisig HD Bitcoin Wallet, demo for Bitcore Wallet Service",
   "author": "BitPay Inc",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "keywords": [
     "bitcoin",
     "copay",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "url": "https://github.com/bitpay/bitcore-wallet/issues"
   },
   "dependencies": {
-    "bitcore-wallet-client": "0.0.22",
     "commander": "^2.6.0",
     "lodash": "^3.3.1",
     "moment": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/bitpay/bitcore-wallet/issues"
   },
   "dependencies": {
+    "bitcore-wallet-client": "0.0.33",
     "commander": "^2.6.0",
     "lodash": "^3.3.1",
     "moment": "^2.9.0",


### PR DESCRIPTION
 - update dependencies
 - point by default to Bitpay's public BWS instance.