### PR TITLE
Pass "coin" to wallet-client options as well

### DIFF
--- a/bin/wallet-create
+++ b/bin/wallet-create
@@ -39,7 +39,8 @@ utils.getClient(program, {
     coin: coin,
   });
   client.createWallet(walletName, copayerName, mn[0], mn[1], {
-    network: network
+    network: network,
+    coin: coin
   }, function(err, secret) {
     utils.die(err);
     console.log(' * ' + _.capitalize(network) + ' Wallet Created.');


### PR DESCRIPTION
Without this change, I was unable to successfully create a `bch` `testnet` wallet using:

```
wallet create bch-testnet 1-1 -c bch -t
```

I would get this error:

```
Error: Existing keys were created for a different coin
    at API.createWallet (/usr/local/lib/node_modules/bitcore-wallet/node_modules/bitcore-wallet-client/lib/api.js:1324:15)
```